### PR TITLE
Add Discord notifications to all CI workflows

### DIFF
--- a/.github/workflows/ember-cli.yml
+++ b/.github/workflows/ember-cli.yml
@@ -60,12 +60,15 @@ jobs:
       - uses: wyvox/action-setup-pnpm@v3
       - run: pnpm test:library ${{ matrix.args }}
 
-  # TODO: post to Discord?
-  # output:
-  #   needs: [new_library, new_app, ecosystem]
-  #   if: always()
-  #   name: 'Output'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: wyvox/action-setup-pnpm@v3
+  notify:
+    name: "Discord Notification"
+    needs: [new_app, new_library]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ (needs.new_app.result == 'success' && needs.new_library.result == 'success') && 'success' || 'failure' }}
+          title: "ember-cli @ main"
+          description: "Ecosystem CI results for ember-cli @ main"

--- a/.github/workflows/ember-cli.yml
+++ b/.github/workflows/ember-cli.yml
@@ -63,7 +63,7 @@ jobs:
   notify:
     name: "Discord Notification"
     needs: [new_app, new_library]
-    if: always()
+    if: failure()
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/ember-source.yml
+++ b/.github/workflows/ember-source.yml
@@ -105,7 +105,7 @@ jobs:
   notify:
     name: "Discord Notification"
     needs: [ecosystem]
-    if: always()
+    if: failure()
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/ember-source.yml
+++ b/.github/workflows/ember-source.yml
@@ -102,12 +102,15 @@ jobs:
       - name: "Test"
         run: pnpm ci:run ./src/ci/run/test.ts --name=${{matrix.name}}
 
-  # TODO: post to Discord?
-  # output:
-  #   needs: [new_library, new_app, ecosystem]
-  #   if: always()
-  #   name: 'Output'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: wyvox/action-setup-pnpm@v3
+  notify:
+    name: "Discord Notification"
+    needs: [ecosystem]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ needs.ecosystem.result }}
+          title: "ember-source @ main"
+          description: "Ecosystem CI results for ember-source @ main"

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -43,3 +43,16 @@ jobs:
             --test="ts" \
             --cli-version="${{ matrix.lts }}" \
             --devDependency="typescript@${{ matrix.ts }}"
+
+  notify:
+    name: "Discord Notification"
+    needs: [ts_support]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ needs.ts_support.result }}
+          title: "LTS Support"
+          description: "Rolling TS support matrix results"

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -47,7 +47,7 @@ jobs:
   notify:
     name: "Discord Notification"
     needs: [ts_support]
-    if: always()
+    if: failure()
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## Summary
- Adds a `notify` job to all 3 workflows (ember-source, ember-cli, LTS) that posts results to Discord after all test jobs complete
- Uses [`sarisia/actions-status-discord@v1`](https://github.com/sarisia/actions-status-discord) which auto-generates color-coded embeds (green/red/yellow) with repo, branch, and commit context
- Replaces the commented-out `output` job TODOs

## Setup required
Add `DISCORD_WEBHOOK_URL` as a repository secret containing the Discord webhook URL.

## Test plan
- [ ] Configure `DISCORD_WEBHOOK_URL` secret
- [ ] Trigger a workflow run and verify Discord receives the notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)